### PR TITLE
Make tasks compatible with babashka

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,7 +5,9 @@
   org.clojure/tools.deps.alpha {:mvn/version "0.12.1071"}
   ;org.clojure/tools.deps.alpha {:git/url "https://github.com/clojure/tools.deps.alpha.git"
   ;                              :sha "459222ca6e4fce91cf5838435589a028cedbc784"}
-  org.clojure/tools.namespace {:mvn/version "1.0.0"}
+  org.clojure/tools.namespace
+  {:git/url "https://github.com/babashka/tools.namespace"
+   :git/sha "3625153ee66dfcec2ba600851b5b2cbdab8fae6c"}
   org.slf4j/slf4j-nop {:mvn/version "1.7.32"}}
 
  :aliases

--- a/src/main/clojure/clojure/tools/build/tasks/compile_clj.clj
+++ b/src/main/clojure/clojure/tools/build/tasks/compile_clj.clj
@@ -35,7 +35,7 @@
 
 (defn- ns->path
   [ns-sym]
-  (str/replace (clojure.lang.Compiler/munge (str ns-sym)) \. \/))
+  (str/replace (munge (str ns-sym)) \. \/))
 
 (defn- nses-in-bfs
   [dirs]

--- a/src/main/clojure/clojure/tools/build/tasks/install.clj
+++ b/src/main/clojure/clojure/tools/build/tasks/install.clj
@@ -8,13 +8,11 @@
 
 (ns clojure.tools.build.tasks.install
   (:require
+    [borkdude.tdn.bbuild :as bbuild]
     [clojure.java.io :as jio]
     [clojure.tools.deps.alpha.util.maven :as mvn]
     [clojure.tools.build.api :as api]
-    [clojure.tools.build.util.file :as file])
-  (:import
-    [org.eclipse.aether.artifact DefaultArtifact]
-    [org.eclipse.aether.installation InstallRequest]))
+    [clojure.tools.build.util.file :as file]))
 
 (set! *warn-on-reflection* true)
 
@@ -28,9 +26,9 @@
         pom (jio/file pom-dir "pom.xml")
         system (mvn/make-system)
         session (mvn/make-session system (or local-repo mvn/default-local-repo))
-        jar-artifact (.setFile (DefaultArtifact. group-id artifact-id classifier "jar" version) jar-file-file)
+        jar-artifact (.setFile (bbuild/default-artifact group-id artifact-id classifier "jar" version) jar-file-file)
         artifacts (cond-> [jar-artifact]
-                    (and pom-dir (.exists pom)) (conj (.setFile (DefaultArtifact. group-id artifact-id classifier "pom" version) pom)))
-        install-request (.setArtifacts (InstallRequest.) artifacts)]
+                    (and pom-dir (.exists pom)) (conj (.setFile (bbuild/default-artifact group-id artifact-id classifier "pom" version) pom)))
+        install-request (.setArtifacts (bbuild/install-request) artifacts)]
     (.install system session install-request)
     nil))

--- a/src/main/clojure/clojure/tools/build/tasks/javac.clj
+++ b/src/main/clojure/clojure/tools/build/tasks/javac.clj
@@ -11,27 +11,32 @@
     [clojure.java.io :as jio]
     [clojure.string :as str]
     [clojure.tools.build.api :as api]
+    [clojure.tools.build.tasks.process :as process]
     [clojure.tools.build.util.file :as file])
   (:import
-    [java.io File]
-    [javax.tools ToolProvider DiagnosticListener]))
+    [java.io File]))
 
 (set! *warn-on-reflection* true)
 
 (defn javac
+  "Compile java sources."
   [{:keys [basis javac-opts class-dir src-dirs] :as params}]
-  (let [{:keys [libs]} basis]
-    (when (seq src-dirs)
-      (let [class-dir (file/ensure-dir (api/resolve-path class-dir))
-            compiler (ToolProvider/getSystemJavaCompiler)
-            listener (reify DiagnosticListener (report [_ diag] (println (str diag))))
-            file-mgr (.getStandardFileManager compiler listener nil nil)
-            class-dir-path (.getPath class-dir)
-            classpath (str/join File/pathSeparator (conj (mapcat :paths (vals libs)) class-dir-path))
-            options (concat ["-classpath" classpath "-d" class-dir-path] javac-opts)
-            java-files (mapcat #(file/collect-files (api/resolve-path %) :collect (file/suffixes ".java")) src-dirs)
-            file-objs (.getJavaFileObjectsFromFiles file-mgr java-files)
-            task (.getTask compiler nil file-mgr listener options nil file-objs)
-            success (.call task)]
-        (when-not success
-          (throw (ex-info "Java compilation failed" {})))))))
+
+  (when (seq src-dirs)
+    (let [{:keys [libs]} basis
+          class-dir (file/ensure-dir (api/resolve-path class-dir))
+          class-dir-path (.getPath class-dir)
+          classpath (str/join File/pathSeparator (conj (mapcat :paths (vals libs)) class-dir-path))
+          options (concat ["-classpath" classpath "-d" class-dir-path] javac-opts)
+          java-files (mapcat #(file/collect-files (api/resolve-path %) :collect (file/suffixes ".java")) src-dirs)
+          java-files (map str java-files)
+
+          args          (-> ["javac"
+                            ;; "-sourcepath" (str/join ":" src-dirs)
+                             ]
+                            (into options)
+                            (into java-files))]
+      (file/ensure-dir class-dir)
+      (process/process
+       {:command-args args
+        :out :capture}))))


### PR DESCRIPTION
Updates tasks to use babashka/tools.namespace, and
borkdude/tools-deps-native-experiment.

The compile-clj changes to use clojure.core/munge instead of the
Compiler internal.

install changes to use a helper from tools-deps-native-experiment to
construct maven objects.

javac changes to use the javac command line.