### PR TITLE
babashka tooling to run tests

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,16 @@
+{:paths ["src/main/clojure" "script"]
+ :deps  {org.clojure/tools.namespace
+         {:git/url "https://github.com/borkdude/tools.namespace"
+          :git/sha "ee3b30a1741a3e35b0ed8f387e1fbef43ff40d3f"}}
+ :tasks {require-deps (load-file "script/require_deps.clj")
+         test {:doc "Run test with cognitect test runner"
+               :depends [require-deps]
+               :extra-paths ["src/test/clojure"]
+               :extra-deps
+               {io.github.cognitect-labs/test-runner
+                {:git/tag "v0.5.0" :git/sha "48c3c67"}}
+               :requires ([cognitect.test-runner :as tr])
+               :task (apply tr/-main
+                            "-d" "src/test/clojure"
+                            "-r" ".*test-.*"
+                            *command-line-args*)}}}

--- a/script/require_all.clj
+++ b/script/require_all.clj
@@ -1,0 +1,13 @@
+(ns require-all
+  (:require [require-deps]))
+
+(require 'clojure.tools.build.api)
+(require 'clojure.tools.build.tasks.compile-clj)
+(require 'clojure.tools.build.tasks.copy)
+(require 'clojure.tools.build.tasks.create-basis)
+(require 'clojure.tools.build.tasks.install)
+(require 'clojure.tools.build.tasks.jar)
+(require 'clojure.tools.build.tasks.javac)
+(require 'clojure.tools.build.tasks.process)
+(require 'clojure.tools.build.tasks.uber)
+(require 'clojure.tools.build.tasks.write-pom)

--- a/script/require_deps.clj
+++ b/script/require_deps.clj
@@ -1,0 +1,12 @@
+(ns require-deps
+  (:require [babashka.deps :as deps]
+            [babashka.pods :as pods]))
+
+(pods/load-pod "tools-deps-native")
+
+(deps/add-deps
+ '{:deps {borkdude/spartan.spec
+          {:git/url "https://github.com/borkdude/spartan.spec"
+           :sha     "12947185b4f8b8ff8ee3bc0f19c98dbde54d4c90"}}})
+
+(require 'spartan.spec)


### PR DESCRIPTION
Adds a bb.edn config to run tests with the cognitect test-runner.

Uses a script/require_deps.clj script to load the tools-deps-native pod
and spartan.